### PR TITLE
Fix recipe overlap for deploying

### DIFF
--- a/common/src/generated/resources/data/extendedgears/recipes/deploying/half_shaft_cogwheel.json
+++ b/common/src/generated/resources/data/extendedgears/recipes/deploying/half_shaft_cogwheel.json
@@ -2,7 +2,7 @@
   "type": "create:deploying",
   "ingredients": [
     {
-      "item": "create:shaft"
+      "item": "create:andesite_alloy"
     },
     {
       "tag": "minecraft:planks"

--- a/common/src/generated/resources/data/extendedgears/recipes/deploying/shaftless_cogwheel.json
+++ b/common/src/generated/resources/data/extendedgears/recipes/deploying/shaftless_cogwheel.json
@@ -2,7 +2,7 @@
   "type": "create:deploying",
   "ingredients": [
     {
-      "item": "create:shaft"
+      "tag": "minecraft:buttons"
     },
     {
       "tag": "minecraft:planks"


### PR DESCRIPTION
The recipes were inconsistent with the crafting previously. They also overwrote the existing cogwheel recipe via deploying.